### PR TITLE
Add cross-ecosystem post-quantum planning context

### DIFF
--- a/CPS-0000/README.md
+++ b/CPS-0000/README.md
@@ -53,6 +53,11 @@ exchanges, and other ecosystem participants. It also requires broad community
 alignment and careful rollout planning. As a result, Cardano cannot wait until
 the risk becomes immediate before preparing a migration path.
 
+This is not unique to Cardano. Other major blockchain ecosystems are also
+moving from general concern to public planning, including XRP Ledger's
+published post-quantum roadmap and Ethereum Foundation work on post-quantum
+protocol upgrades.
+
 Cardano exposes many public keys on-chain, and some of them remain in use for
 long periods of time. This increases the risk that long-exposed public keys
 become attractive targets if quantum attacks on their corresponding private


### PR DESCRIPTION
This PR adds a short sentence in the `Context: why this matters now`.

The goal is to strengthen the urgency argument by noting that Cardano is not alone in this discussion. Other major blockchain ecosystems, including XRP Ledger and Ethereum, are also moving from general concern to public post-quantum planning.


Closes https://github.com/perturbing/CIPs/issues/6