### PR TITLE
Add section on other ecosystems activity

### DIFF
--- a/CPS-0000/README.md
+++ b/CPS-0000/README.md
@@ -141,6 +141,18 @@ today's settlement layer, but also affects important Cardano services and
 future consensus designs.
 
 
+### Post-quantum planning in other ecosystems
+
+Cardano is not the only ecosystem facing this problem. Other major blockchain projects are also moving from general concern to active planning and, in some cases, shipped work. Security models, consensus mechanisms, and governance processes differ significantly across ecosystems, so direct comparisons are limited. The general direction, however, is consistent: public-key cryptography needs to be replaced, and the planning window is now.
+
+Ethereum has the most active public programme. The Ethereum Foundation formed a dedicated [Post-Quantum Security team in January 2026](https://www.coindesk.com/tech/2026/01/24/ethereum-foundation-makes-post-quantum-security-a-top-priority-as-new-team-forms), backed by $2 million in research prizes, and launched a public tracking hub at [pq.ethereum.org](https://pq.ethereum.org/). On the protocol side, [EIP-8141](https://eips.ethereum.org/EIPS/eip-8141), co-authored by Vitalik Buterin, introduces native account abstraction that allows accounts to migrate from ECDSA to post-quantum schemes such as ML-DSA without changing their address, building on the programmable transaction validation model established by ERC-4337. At the consensus and data availability layers, the [Lean Ethereum initiative](https://blog.ethereum.org/2025/07/31/lean-ethereum) proposes replacing BLS aggregate signatures with hash-based schemes and KZG commitments with hash-based alternatives, with a minimal SNARK-friendly execution layer as a longer-term goal. These concerns map directly onto the categories identified in the Cardano threat model above: signature schemes, aggregate certificates, and elliptic-curve-based proof systems.
+
+Algorand has the most mature shipped work. [State Proofs using Falcon signatures](https://algorand.co/technology/post-quantum) were deployed in March 2022, providing quantum-resistant cross-chain state verification. In November 2025, Algorand added a native [`falcon_verify`](https://algorand.co/blog/technical-brief-quantum-resistant-transactions-on-algorand-with-falcon-signatures) opcode to its virtual machine and demonstrated the first post-quantum transaction on mainnet. Its VRF-based committee selection remains elliptic-curve-based, an open problem the team has acknowledged.
+
+The XRP Ledger published a [formal post-quantum roadmap in April 2026](https://ripple.com/insights/post-quantum-readiness-on-the-xrp-ledger/), targeting full production transition by 2028. The plan moves through four phases: emergency contingency readiness, experimentation with ML-DSA on a test network, parallel deployment alongside existing signatures, and a network-wide amendment. Its stated design principle is cryptographic agility, supporting multiple NIST-standardised algorithms to remain adaptable as the field matures.
+
+Bitcoin and Solana are at earlier stages. BIP-360 and BIP-361, formally assigned in February 2026, propose a new quantum-resistant output type and a legacy address migration plan respectively, though neither has community consensus for activation. Solana has tested post-quantum signatures experimentally and encountered significant performance overhead, a concrete illustration of the engineering tradeoffs that any ecosystem, including Cardano, must account for in its migration design.
+
 ## Use Cases
 <!-- A concrete set of examples written from a user's perspective, describing what and why they are trying to do. When they exist, this section should give a sense of the current alternatives and highlight why they are not suitable. -->
 

--- a/CPS-0000/README.md
+++ b/CPS-0000/README.md
@@ -53,6 +53,11 @@ exchanges, and other ecosystem participants. It also requires broad community
 alignment and careful rollout planning. As a result, Cardano cannot wait until
 the risk becomes immediate before preparing a migration path.
 
+This is not unique to Cardano. Other major blockchain ecosystems are also
+moving from general concern to public planning, including XRP Ledger's
+published post-quantum roadmap and Ethereum Foundation work on post-quantum
+protocol upgrades.
+
 Cardano exposes many public keys on-chain, and some of them remain in use for
 long periods of time. This increases the risk that long-exposed public keys
 become attractive targets if quantum attacks on their corresponding private


### PR DESCRIPTION
Adds a new `### Post-quantum planning in other ecosystems` subsection to the Problem section.

Covers Ethereum (EF PQ Security team, EIP-8141, Lean Ethereum initiative), Algorand (State Proofs, falcon_verify mainnet), XRP Ledger (4-phase roadmap targeting 2028), and brief mentions of Bitcoin and Solana. Each example is kept high-level. The section closes with a note on engineering tradeoffs relevant to Cardano's own migration planning.

Closes https://github.com/perturbing/CIPs/issues/9
